### PR TITLE
Enable sidekiq metrics

### DIFF
--- a/lib/gvl_metrics_middleware/railtie.rb
+++ b/lib/gvl_metrics_middleware/railtie.rb
@@ -23,7 +23,8 @@ module GvlMetricsMiddleware
     end
 
     initializer "gvl_metrics_middleware.sidekiq" do |app|
-      if defined?(::Sidekiq) && defined?(GvlMetricsMiddleware::Sidekiq) && app.config.gvl_metrics_middleware.enabled
+      if defined?(::Sidekiq) && app.config.gvl_metrics_middleware.enabled
+        require "gvl_metrics_middleware/sidekiq"
         ::Sidekiq.configure_server do |config|
           config.server_middleware do |chain|
             chain.prepend(GvlMetricsMiddleware::Sidekiq)


### PR DESCRIPTION
Railtie initializers run before the initializers in `config/initializers` which results in Sidekiq metrics not being enabled because `GvlMetricsMiddleware::Sidekiq` is not defined.

This fix enables Sidekiq metrics, but there's no way to disable only the Sidekiq metrics.

I wonder if we could move the `gvl_metrics_middleware.rack` and `gvl_metrics_middleware.sidekiq` Railtie initializers to `GvlMetricsMiddleware.rack` and `GvlMetricsMiddleware.sidekiq` methods respectively so that metrics are enabled only if the block is defined?