### PR TITLE
Add a way to associate metrics to a specific sidekiq job

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,19 @@ GvlMetricsMiddleware.configure do |config|
     NewRelic::Agent.record_metric("Custom/Rack/GVL/gvl_wait", gvl_wait)
   end
 
-  config.sidekiq do |total, running, io_wait, gvl_wait|
+  config.sidekiq do |total, running, io_wait, gvl_wait, options|
     NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/total", total)
     NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/running", running)
     NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/io_wait", io_wait)
     NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/gvl_wait", gvl_wait)
+
+    # If you want to record metrics for specific queues and job classes, you can do so like this:
+    queue = options[:queue]
+    job_class = options[:job_class]
+    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/total", total)
+    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/running", running)
+    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/io_wait", io_wait)
+    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/gvl_wait", gvl_wait)
   end
 end
 ```

--- a/lib/gvl_metrics_middleware/sidekiq.rb
+++ b/lib/gvl_metrics_middleware/sidekiq.rb
@@ -17,11 +17,11 @@ module GvlMetricsMiddleware
 
     include ::Sidekiq::ServerMiddleware
 
-    def call(_job_instance, _job_payload, _queue)
+    def call(job_instance, _job_payload, queue)
       gvl_times = GVLTiming.measure { yield }
 
       begin
-        self.class.reporter&.call(gvl_times.duration_ns, gvl_times.running_duration_ns, gvl_times.idle_duration_ns, gvl_times.stalled_duration_ns)
+        self.class.reporter&.call(gvl_times.duration_ns, gvl_times.running_duration_ns, gvl_times.idle_duration_ns, gvl_times.stalled_duration_ns, job_class: job_instance.class.to_s, queue: queue)
       rescue => exception
         GvlMetricsMiddleware.on_report_failure&.call("Sidekiq", exception)
 

--- a/test/gvl_metrics_middleware/rack_test.rb
+++ b/test/gvl_metrics_middleware/rack_test.rb
@@ -8,7 +8,6 @@ class RackMiddlewareTest < ActiveSupport::TestCase
 
   setup do
     @captured_value = []
-
   end
 
   teardown do


### PR DESCRIPTION
Adds a way to associate sidekiq job class and queue to each metric:

```ruby
# config/initializers/gvl_metrics_middleware.rb
GvlMetricsMiddleware.configure do |config|
  ...

  config.sidekiq do |total, running, io_wait, gvl_wait, options|
    queue = options[:queue]
    job_class = options[:job_class]

    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/total", total)
    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/running", running)
    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/io_wait", io_wait)
    NewRelic::Agent.record_metric("Custom/Sidekiq/GVL/#{queue}/#{job_class}/gvl_wait", gvl_wait)
  end
end
```