### PR TITLE
Support of lower versions of sidekiq 

### DIFF
--- a/lib/gvl_metrics_middleware/sidekiq.rb
+++ b/lib/gvl_metrics_middleware/sidekiq.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 require "gvl_timing"
-require "sidekiq/middleware/modules"
+
+if ::Sidekiq::VERSION >= "6.5.0"
+  require "sidekiq/middleware/modules"
+end
 
 module GvlMetricsMiddleware
   class Sidekiq
@@ -15,7 +18,10 @@ module GvlMetricsMiddleware
       end
     end
 
-    include ::Sidekiq::ServerMiddleware
+    if ::Sidekiq::VERSION >= "6.5.0"
+      include ::Sidekiq::ServerMiddleware
+    end
+    
 
     def call(job_instance, _job_payload, queue)
       gvl_times = GVLTiming.measure { yield }


### PR DESCRIPTION
This gem currently doesn't work on my rails app which uses sidekiq `v5.2.9` as this class was only introduced in `v6.4.2`

https://github.com/sidekiq/sidekiq/compare/v6.4.2...v6.5.0. 

With this fix i'm able to get this to work. 

Fixes: #5 