### PR TITLE
Add sampling support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.bundle/
+.bundle/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ application’s `config/initializers`directory:
 ```ruby
 # config/initializers/gvl_metrics_middleware.rb
 GvlMetricsMiddleware.configure do |config|
+  # Optional: Set sampling rate (0.0 to 1.0, defaults to 0.01 for 1% sampling)
+  config.sampling_rate = 0.1 # Sample 10% of requests/jobs
+
   config.rack do |total, running, io_wait, gvl_wait|
     # Your code here...
   end
@@ -37,6 +40,9 @@ For example, if you would like to record the GVL metrics in New Relic, you can u
 ```ruby
 # config/initializers/gvl_metrics_middleware.rb
 GvlMetricsMiddleware.configure do |config|
+  # Increase sampling from default 1% to 10% for more data
+  config.sampling_rate = 0.1
+
   config.rack do |total, running, io_wait, gvl_wait|
     NewRelic::Agent.record_metric("Custom/Rack/GVL/total", total)
     NewRelic::Agent.record_metric("Custom/Rack/GVL/running", running)
@@ -79,6 +85,24 @@ The `gvl_metrics_middleware` reports the following metrics. The metrics are all 
   value returned by the `GVLTiming::Timer#idle_duration` method.
 - **`gvl_wait`**: The time spent waiting to acquire the GVL. This corresponds to the value returned by
   the `GVLTiming::Timer#stalled_duration` method.
+
+## Sampling
+
+By default, the middleware samples 1% of requests and jobs to minimize overhead. You can adjust this sampling rate:
+```ruby
+GvlMetricsMiddleware.configure do |config|
+  # Sample 25% of requests/jobs
+  config.sampling_rate = 0.25
+
+  # Your reporters here...
+end
+```
+
+The `sampling_rate` option accepts a value between `0.0` (no sampling) and `1.0` (100% sampling). The default is `0.01` (1%).
+
+The middleware will randomly decide whether to instrument each request or job based on the configured rate. The default 1% sampling provides meaningful metrics while maintaining minimal performance overhead.
+
+**Important**: Your metrics will only represent the sampled portion of traffic. You may need to adjust your alerting and analysis accordingly.
 
 ## Performance Overhead
 

--- a/lib/gvl_metrics_middleware.rb
+++ b/lib/gvl_metrics_middleware.rb
@@ -42,4 +42,26 @@ module GvlMetricsMiddleware
   def self.safe_guard=(value)
     @@safe_guard = value
   end
+
+  @@sampling_rate = 0.01
+
+  def self.sampling_rate
+    @@sampling_rate
+  end
+
+  def self.sampling_rate=(rate)
+    rate = rate.to_f
+    if rate < 0.0 || rate > 1.0
+      raise ArgumentError, "sampling_rate must be between 0.0 and 1.0, got #{rate}"
+    end
+
+    @@sampling_rate = rate
+  end
+
+  def self.should_sample?
+    return true if @@sampling_rate == 1.0
+    return false if @@sampling_rate == 0.0
+
+    rand < @@sampling_rate
+  end
 end

--- a/lib/gvl_metrics_middleware/rack.rb
+++ b/lib/gvl_metrics_middleware/rack.rb
@@ -19,6 +19,8 @@ module GvlMetricsMiddleware
     end
 
     def call(env)
+      return @app.call(env) unless GvlMetricsMiddleware.should_sample?
+
       response = nil
 
       gvl_times = GVLTiming.measure do

--- a/lib/gvl_metrics_middleware/sidekiq.rb
+++ b/lib/gvl_metrics_middleware/sidekiq.rb
@@ -18,6 +18,8 @@ module GvlMetricsMiddleware
     include ::Sidekiq::ServerMiddleware
 
     def call(job_instance, _job_payload, queue)
+      return yield unless GvlMetricsMiddleware.should_sample?
+
       gvl_times = GVLTiming.measure { yield }
 
       begin

--- a/test/gvl_metrics_middleware/configuration_test.rb
+++ b/test/gvl_metrics_middleware/configuration_test.rb
@@ -30,4 +30,51 @@ class ConfigurationTest < ActiveSupport::TestCase
 
     assert_same hook, GvlMetricsMiddleware::Sidekiq.reporter
   end
+
+  test "sampling_rate can be set and retrieved" do
+    GvlMetricsMiddleware.sampling_rate = 0.5
+    assert_equal 0.5, GvlMetricsMiddleware.sampling_rate
+  end
+
+  test "sampling_rate defaults to 0.01" do
+    assert_equal 0.01, GvlMetricsMiddleware.sampling_rate
+  end
+
+  test "sampling_rate raises error for values outside 0.0-1.0 range" do
+    assert_raises(ArgumentError) { GvlMetricsMiddleware.sampling_rate = -0.1 }
+    assert_raises(ArgumentError) { GvlMetricsMiddleware.sampling_rate = 1.1 }
+  end
+
+  test "sampling_rate converts string values to float" do
+    GvlMetricsMiddleware.sampling_rate = "0.25"
+    assert_equal 0.25, GvlMetricsMiddleware.sampling_rate
+  end
+
+  test "should_sample? returns true when sampling_rate is 1.0" do
+    GvlMetricsMiddleware.sampling_rate = 1.0
+    assert GvlMetricsMiddleware.should_sample?
+  end
+
+  test "should_sample? returns false when sampling_rate is 0.0" do
+    GvlMetricsMiddleware.sampling_rate = 0.0
+    refute GvlMetricsMiddleware.should_sample?
+  end
+
+  test "should_sample? respects sampling rate probabilistically" do
+    GvlMetricsMiddleware.sampling_rate = 0.5
+
+    samples = 1000.times.map { GvlMetricsMiddleware.should_sample? }
+    true_count = samples.count(true)
+
+    assert_operator true_count, :>, 400
+    assert_operator true_count, :<, 600
+  end
+
+  test "#configure block allows for setting sampling_rate" do
+    GvlMetricsMiddleware.configure do |config|
+      config.sampling_rate = 0.3
+    end
+
+    assert_equal 0.3, GvlMetricsMiddleware.sampling_rate
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,6 +18,7 @@ class ActiveSupport::TestCase
   private
 
   def reset
+    GvlMetricsMiddleware.sampling_rate = 0.01
     GvlMetricsMiddleware::Rack.reporter = nil
     GvlMetricsMiddleware::Sidekiq.reporter = nil
   end


### PR DESCRIPTION
Hello, we're trying this out at @buildkite and would like to only collect metrics on a sample of requests in production. This PR adds configurable sampling support to both the rack and sidekiq middleware.

The sampling rate is configurable via `config.sampling_rate` (0.0 to 1.0), and the middleware skips instrumentation randomly based on that rate.