### PR TITLE
Allow middleware configuration in initializers

### DIFF
--- a/lib/gvl_metrics_middleware/railtie.rb
+++ b/lib/gvl_metrics_middleware/railtie.rb
@@ -8,7 +8,7 @@ module GvlMetricsMiddleware
     config.gvl_metrics_middleware.enabled = !Rails.env.test?
     config.gvl_metrics_middleware.safe_guard = Rails.env.production?
 
-    initializer "gvl_metrics_middleware" do |app|
+    initializer "gvl_metrics_middleware", after: :load_config_initializers do |app|
       if app.config.gvl_metrics_middleware.enabled && app.config.gvl_metrics_middleware.safe_guard
         GvlMetricsMiddleware.on_report_failure.nil? && GvlMetricsMiddleware.on_report_failure do |source, exception|
           Rails.logger.error("GVL Metrics Middleware failed to report metrics from #{source}: #{exception.class} (#{exception.message})")
@@ -18,11 +18,11 @@ module GvlMetricsMiddleware
       end
     end
 
-    initializer "gvl_metrics_middleware.rack" do |app|
+    initializer "gvl_metrics_middleware.rack", after: :load_config_initializers do |app|
       app.config.middleware.insert(0, GvlMetricsMiddleware::Rack) if app.config.gvl_metrics_middleware.enabled
     end
 
-    initializer "gvl_metrics_middleware.sidekiq" do |app|
+    initializer "gvl_metrics_middleware.sidekiq", after: :load_config_initializers do |app|
       if defined?(::Sidekiq) && app.config.gvl_metrics_middleware.enabled
         require "gvl_metrics_middleware/sidekiq"
         ::Sidekiq.configure_server do |config|

--- a/test/test_in_isolation_helper.rb
+++ b/test/test_in_isolation_helper.rb
@@ -77,6 +77,12 @@ module Generation
     end
   end
 
+  def add_initializer(name, contents)
+    File.open("#{app_path}/config/initializers/#{name}.rb", "w") do |f|
+      f.puts contents
+    end
+  end
+
   def self.initialize_app
     FileUtils.rm_rf(app_template_path)
     FileUtils.mkdir(app_template_path)


### PR DESCRIPTION
Defers middleware insertion until after `config/initializers/` files load, allowing users to configure the gem in their own initializers.

<details>
<summary>Local test run results</summary>

<br>

**Note:** There's an unrelated test that currently fails on main which I won't be addressing here.

Before:
```
gvl_metrics_middleware [allow-initializer-config] be rake
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/gvl_metrics_middleware/configuration_test.rb" "test/gvl_metrics_middleware/rack_test.rb" "test/gvl_metrics_middleware/sidekiq_test.rb"
/Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/sidekiq-8.0.8/lib/sidekiq/testing.rb:332: warning: global variable '$TESTING' not initialized
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/bundled_gems.rb:82: warning: ⛔️ WARNING: Sidekiq testing API enabled, but this is not the test environment.  Your jobs will not go to Redis.
Run options: --seed 64592

# Running:

..INFO  2025-10-28T04:41:48.058Z pid=35802 tid=rtu: Sidekiq 8.0.8 connecting to Redis with options {size: 10, pool_name: "internal", url: nil}
....

Fabulous run in 4.023882s, 1.4911 runs/s, 4.7218 assertions/s.

6 runs, 19 assertions, 0 failures, 0 errors, 0 skips
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/isolated/**/*_test.rb"
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Run options: --seed 17086

# Running:

..FF....F

Fabulous run in 0.426439s, 21.1050 runs/s, 42.2100 assertions/s.

  1) Failure:
RailtieTest#test_allows_rack_middleware_configuration_in_initializers_before_middleware_is_added [test/isolated/railtie_test.rb:45]:
Expected ["GvlMetricsMiddleware::Rack", "ActionDispatch::HostAuthorization", "Rack::Sendfile", "ActionDispatch::Static", "ActionDispatch::Executor", "Rack::Runtime", "Rack::MethodOverride", "ActionDispatch::RequestId", "ActionDispatch::RemoteIp", "Rails::Rack::Logger", "ActionDispatch::ShowExceptions", "ActionDispatch::DebugExceptions", "ActionDispatch::Reloader", "ActionDispatch::Callbacks", "ActionDispatch::Cookies", "ActionDispatch::Session::CookieStore", "ActionDispatch::Flash", "ActionDispatch::ContentSecurityPolicy::Middleware", "Rack::Head", "Rack::ConditionalGet", "Rack::ETag", "Rack::TempfileReaper"] to not include "GvlMetricsMiddleware::Rack".

  2) Failure:
RailtieTest#test_does_not_insert_the_sidekiq_middleware_when_explicitly_enabled_but_not_set_up [test/isolated/railtie_test.rb:73]:
Expected ["GvlMetricsMiddleware::Sidekiq"] to not include "GvlMetricsMiddleware::Sidekiq".

  3) Failure:
RailtieTest#test_allows_sidekiq_middleware_configuration_in_initializers_before_middleware_is_added [test/isolated/railtie_test.rb:97]:
Expected ["GvlMetricsMiddleware::Sidekiq"] to not include "GvlMetricsMiddleware::Sidekiq".

9 runs, 18 assertions, 3 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/isolated/**/*_test.rb" ]
/Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/exe/rake:27:in '<top (required)>'
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/bundle:25:in '<main>'
Tasks: TOP => default => test:isolated
(See full trace by running task with --trace)
```

After:
```
gvl_metrics_middleware [allow-initializer-config] be rake
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/gvl_metrics_middleware/configuration_test.rb" "test/gvl_metrics_middleware/rack_test.rb" "test/gvl_metrics_middleware/sidekiq_test.rb"
/Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/sidekiq-8.0.8/lib/sidekiq/testing.rb:332: warning: global variable '$TESTING' not initialized
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/bundled_gems.rb:82: warning: ⛔️ WARNING: Sidekiq testing API enabled, but this is not the test environment.  Your jobs will not go to Redis.
Run options: --seed 7494

# Running:

....INFO  2025-10-28T04:40:41.617Z pid=35612 tid=rok: Sidekiq 8.0.8 connecting to Redis with options {size: 10, pool_name: "internal", url: nil}
..

Fabulous run in 4.023441s, 1.4913 runs/s, 4.7223 assertions/s.

6 runs, 19 assertions, 0 failures, 0 errors, 0 skips
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/isolated/**/*_test.rb"
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Could not find gem 'rails (~> 8.2.0.alpha)' in rubygems repository https://rubygems.org/ or installed locally.

The source contains the following gems matching 'rails':
  * rails-0.8.0
  * rails-0.8.5
  * rails-0.9.0
  * rails-0.9.1
  * rails-0.9.2
  * rails-0.9.3
  * rails-0.9.4
  * rails-0.9.4.1
  * rails-0.9.5
  * rails-0.10.0
  * rails-0.10.1
  * rails-0.11.0
  * rails-0.11.1
  * rails-0.12.0
  * rails-0.12.1
  * rails-0.13.0
  * rails-0.13.1
  * rails-0.14.1
  * rails-0.14.2
  * rails-0.14.3
  * rails-0.14.4
  * rails-1.0.0
  * rails-1.1.0
  * rails-1.1.1
  * rails-1.1.2
  * rails-1.1.3
  * rails-1.1.4
  * rails-1.1.5
  * rails-1.1.6
  * rails-1.2.0
  * rails-1.2.1
  * rails-1.2.2
  * rails-1.2.3
  * rails-1.2.4
  * rails-1.2.5
  * rails-1.2.6
  * rails-2.0.0
  * rails-2.0.1
  * rails-2.0.2
  * rails-2.0.4
  * rails-2.0.5
  * rails-2.1.0
  * rails-2.1.1
  * rails-2.1.2
  * rails-2.2.2
  * rails-2.2.3
  * rails-2.3.2
  * rails-2.3.3
  * rails-2.3.4
  * rails-2.3.5
  * rails-2.3.6
  * rails-2.3.7
  * rails-2.3.8.pre1
  * rails-2.3.8
  * rails-2.3.9.pre
  * rails-2.3.9
  * rails-2.3.10
  * rails-2.3.11
  * rails-2.3.12
  * rails-2.3.14
  * rails-2.3.15
  * rails-2.3.16
  * rails-2.3.17
  * rails-2.3.18
  * rails-3.0.0.beta
  * rails-3.0.0.beta2
  * rails-3.0.0.beta3
  * rails-3.0.0.beta4
  * rails-3.0.0.rc
  * rails-3.0.0.rc2
  * rails-3.0.0
  * rails-3.0.1
  * rails-3.0.2
  * rails-3.0.3
  * rails-3.0.4.rc1
  * rails-3.0.4
  * rails-3.0.5.rc1
  * rails-3.0.5
  * rails-3.0.6.rc1
  * rails-3.0.6.rc2
  * rails-3.0.6
  * rails-3.0.7.rc1
  * rails-3.0.7.rc2
  * rails-3.0.7
  * rails-3.0.8.rc1
  * rails-3.0.8.rc2
  * rails-3.0.8.rc4
  * rails-3.0.8
  * rails-3.0.9.rc1
  * rails-3.0.9.rc3
  * rails-3.0.9.rc4
  * rails-3.0.9.rc5
  * rails-3.0.9
  * rails-3.0.10.rc1
  * rails-3.0.10
  * rails-3.0.11
  * rails-3.0.12.rc1
  * rails-3.0.12
  * rails-3.0.13.rc1
  * rails-3.0.13
  * rails-3.0.14
  * rails-3.0.15
  * rails-3.0.16
  * rails-3.0.17
  * rails-3.0.18
  * rails-3.0.19
  * rails-3.0.20
  * rails-3.1.0.beta1
  * rails-3.1.0.rc1
  * rails-3.1.0.rc2
  * rails-3.1.0.rc3
  * rails-3.1.0.rc4
  * rails-3.1.0.rc5
  * rails-3.1.0.rc6
  * rails-3.1.0.rc8
  * rails-3.1.0
  * rails-3.1.1.rc1
  * rails-3.1.1.rc2
  * rails-3.1.1.rc3
  * rails-3.1.1
  * rails-3.1.2.rc1
  * rails-3.1.2.rc2
  * rails-3.1.2
  * rails-3.1.3
  * rails-3.1.4.rc1
  * rails-3.1.4
  * rails-3.1.5.rc1
  * rails-3.1.5
  * rails-3.1.6
  * rails-3.1.7
  * rails-3.1.8
  * rails-3.1.9
  * rails-3.1.10
  * rails-3.1.11
  * rails-3.1.12
  * rails-3.2.0.rc1
  * rails-3.2.0.rc2
  * rails-3.2.0
  * rails-3.2.1
  * rails-3.2.2.rc1
  * rails-3.2.2
  * rails-3.2.3.rc1
  * rails-3.2.3.rc2
  * rails-3.2.3
  * rails-3.2.4.rc1
  * rails-3.2.4
  * rails-3.2.5
  * rails-3.2.6
  * rails-3.2.7.rc1
  * rails-3.2.7
  * rails-3.2.8.rc1
  * rails-3.2.8.rc2
  * rails-3.2.8
  * rails-3.2.9.rc1
  * rails-3.2.9.rc2
  * rails-3.2.9.rc3
  * rails-3.2.9
  * rails-3.2.10
  * rails-3.2.11
  * rails-3.2.12
  * rails-3.2.13.rc1
  * rails-3.2.13.rc2
  * rails-3.2.13
  * rails-3.2.14.rc1
  * rails-3.2.14.rc2
  * rails-3.2.14
  * rails-3.2.15.rc1
  * rails-3.2.15.rc2
  * rails-3.2.15.rc3
  * rails-3.2.15
  * rails-3.2.16
  * rails-3.2.17
  * rails-3.2.18
  * rails-3.2.19
  * rails-3.2.20
  * rails-3.2.21
  * rails-3.2.22
  * rails-3.2.22.1
  * rails-3.2.22.2
  * rails-3.2.22.3
  * rails-3.2.22.4
  * rails-3.2.22.5
  * rails-4.0.0.beta1
  * rails-4.0.0.rc1
  * rails-4.0.0.rc2
  * rails-4.0.0
  * rails-4.0.1.rc1
  * rails-4.0.1.rc2
  * rails-4.0.1.rc3
  * rails-4.0.1.rc4
  * rails-4.0.1
  * rails-4.0.2
  * rails-4.0.3
  * rails-4.0.4.rc1
  * rails-4.0.4
  * rails-4.0.5
  * rails-4.0.6.rc1
  * rails-4.0.6.rc2
  * rails-4.0.6.rc3
  * rails-4.0.6
  * rails-4.0.7
  * rails-4.0.8
  * rails-4.0.9
  * rails-4.0.10.rc1
  * rails-4.0.10.rc2
  * rails-4.0.10
  * rails-4.0.11
  * rails-4.0.11.1
  * rails-4.0.12
  * rails-4.0.13.rc1
  * rails-4.0.13
  * rails-4.1.0.beta1
  * rails-4.1.0.beta2
  * rails-4.1.0.rc1
  * rails-4.1.0.rc2
  * rails-4.1.0
  * rails-4.1.1
  * rails-4.1.2.rc1
  * rails-4.1.2.rc2
  * rails-4.1.2.rc3
  * rails-4.1.2
  * rails-4.1.3
  * rails-4.1.4
  * rails-4.1.5
  * rails-4.1.6.rc1
  * rails-4.1.6.rc2
  * rails-4.1.6
  * rails-4.1.7
  * rails-4.1.7.1
  * rails-4.1.8
  * rails-4.1.9.rc1
  * rails-4.1.9
  * rails-4.1.10.rc1
  * rails-4.1.10.rc2
  * rails-4.1.10.rc3
  * rails-4.1.10.rc4
  * rails-4.1.10
  * rails-4.1.11
  * rails-4.1.12.rc1
  * rails-4.1.12
  * rails-4.1.13.rc1
  * rails-4.1.13
  * rails-4.1.14.rc1
  * rails-4.1.14.rc2
  * rails-4.1.14
  * rails-4.1.14.1
  * rails-4.1.14.2
  * rails-4.1.15.rc1
  * rails-4.1.15
  * rails-4.1.16.rc1
  * rails-4.1.16
  * rails-4.2.0.beta1
  * rails-4.2.0.beta2
  * rails-4.2.0.beta3
  * rails-4.2.0.beta4
  * rails-4.2.0.rc1
  * rails-4.2.0.rc2
  * rails-4.2.0.rc3
  * rails-4.2.0
  * rails-4.2.1.rc1
  * rails-4.2.1.rc2
  * rails-4.2.1.rc3
  * rails-4.2.1.rc4
  * rails-4.2.1
  * rails-4.2.2
  * rails-4.2.3.rc1
  * rails-4.2.3
  * rails-4.2.4.rc1
  * rails-4.2.4
  * rails-4.2.5.rc1
  * rails-4.2.5.rc2
  * rails-4.2.5
  * rails-4.2.5.1
  * rails-4.2.5.2
  * rails-4.2.6.rc1
  * rails-4.2.6
  * rails-4.2.7.rc1
  * rails-4.2.7
  * rails-4.2.7.1
  * rails-4.2.8.rc1
  * rails-4.2.8
  * rails-4.2.9.rc1
  * rails-4.2.9.rc2
  * rails-4.2.9
  * rails-4.2.10.rc1
  * rails-4.2.10
  * rails-4.2.11
  * rails-4.2.11.1
  * rails-4.2.11.2
  * rails-4.2.11.3
  * rails-5.0.0.beta1
  * rails-5.0.0.beta1.1
  * rails-5.0.0.beta2
  * rails-5.0.0.beta3
  * rails-5.0.0.beta4
  * rails-5.0.0.racecar1
  * rails-5.0.0.rc1
  * rails-5.0.0.rc2
  * rails-5.0.0
  * rails-5.0.0.1
  * rails-5.0.1.rc1
  * rails-5.0.1.rc2
  * rails-5.0.1
  * rails-5.0.2.rc1
  * rails-5.0.2
  * rails-5.0.3
  * rails-5.0.4.rc1
  * rails-5.0.4
  * rails-5.0.5.rc1
  * rails-5.0.5.rc2
  * rails-5.0.5
  * rails-5.0.6.rc1
  * rails-5.0.6
  * rails-5.0.7
  * rails-5.0.7.1
  * rails-5.0.7.2
  * rails-5.1.0.beta1
  * rails-5.1.0.rc1
  * rails-5.1.0.rc2
  * rails-5.1.0
  * rails-5.1.1
  * rails-5.1.2.rc1
  * rails-5.1.2
  * rails-5.1.3.rc1
  * rails-5.1.3.rc2
  * rails-5.1.3.rc3
  * rails-5.1.3
  * rails-5.1.4.rc1
  * rails-5.1.4
  * rails-5.1.5.rc1
  * rails-5.1.5
  * rails-5.1.6
  * rails-5.1.6.1
  * rails-5.1.6.2
  * rails-5.1.7.rc1
  * rails-5.1.7
  * rails-5.2.0.beta1
  * rails-5.2.0.beta2
  * rails-5.2.0.rc1
  * rails-5.2.0.rc2
  * rails-5.2.0
  * rails-5.2.1.rc1
  * rails-5.2.1
  * rails-5.2.1.1
  * rails-5.2.2.rc1
  * rails-5.2.2
  * rails-5.2.2.1
  * rails-5.2.3.rc1
  * rails-5.2.3
  * rails-5.2.4.rc1
  * rails-5.2.4
  * rails-5.2.4.1
  * rails-5.2.4.2
  * rails-5.2.4.3
  * rails-5.2.4.4
  * rails-5.2.4.5
  * rails-5.2.4.6
  * rails-5.2.5
  * rails-5.2.6
  * rails-5.2.6.1
  * rails-5.2.6.2
  * rails-5.2.6.3
  * rails-5.2.7
  * rails-5.2.7.1
  * rails-5.2.8
  * rails-5.2.8.1
  * rails-6.0.0.beta1
  * rails-6.0.0.beta2
  * rails-6.0.0.beta3
  * rails-6.0.0.rc1
  * rails-6.0.0.rc2
  * rails-6.0.0
  * rails-6.0.1.rc1
  * rails-6.0.1
  * rails-6.0.2.rc1
  * rails-6.0.2.rc2
  * rails-6.0.2
  * rails-6.0.2.1
  * rails-6.0.2.2
  * rails-6.0.3.rc1
  * rails-6.0.3
  * rails-6.0.3.1
  * rails-6.0.3.2
  * rails-6.0.3.3
  * rails-6.0.3.4
  * rails-6.0.3.5
  * rails-6.0.3.6
  * rails-6.0.3.7
  * rails-6.0.4
  * rails-6.0.4.1
  * rails-6.0.4.2
  * rails-6.0.4.3
  * rails-6.0.4.4
  * rails-6.0.4.5
  * rails-6.0.4.6
  * rails-6.0.4.7
  * rails-6.0.4.8
  * rails-6.0.5
  * rails-6.0.5.1
  * rails-6.0.6
  * rails-6.0.6.1
  * rails-6.1.0.rc1
  * rails-6.1.0.rc2
  * rails-6.1.0
  * rails-6.1.1
  * rails-6.1.2
  * rails-6.1.2.1
  * rails-6.1.3
  * rails-6.1.3.1
  * rails-6.1.3.2
  * rails-6.1.4
  * rails-6.1.4.1
  * rails-6.1.4.2
  * rails-6.1.4.3
  * rails-6.1.4.4
  * rails-6.1.4.5
  * rails-6.1.4.6
  * rails-6.1.4.7
  * rails-6.1.5
  * rails-6.1.5.1
  * rails-6.1.6
  * rails-6.1.6.1
  * rails-6.1.7
  * rails-6.1.7.1
  * rails-6.1.7.2
  * rails-6.1.7.3
  * rails-6.1.7.4
  * rails-6.1.7.5
  * rails-6.1.7.6
  * rails-6.1.7.7
  * rails-6.1.7.8
  * rails-6.1.7.9
  * rails-6.1.7.10
  * rails-7.0.0.alpha1
  * rails-7.0.0.alpha2
  * rails-7.0.0.rc1
  * rails-7.0.0.rc2
  * rails-7.0.0.rc3
  * rails-7.0.0
  * rails-7.0.1
  * rails-7.0.2
  * rails-7.0.2.1
  * rails-7.0.2.2
  * rails-7.0.2.3
  * rails-7.0.2.4
  * rails-7.0.3
  * rails-7.0.3.1
  * rails-7.0.4
  * rails-7.0.4.1
  * rails-7.0.4.2
  * rails-7.0.4.3
  * rails-7.0.5
  * rails-7.0.5.1
  * rails-7.0.6
  * rails-7.0.7
  * rails-7.0.7.1
  * rails-7.0.7.2
  * rails-7.0.8
  * rails-7.0.8.1
  * rails-7.0.8.2
  * rails-7.0.8.3
  * rails-7.0.8.4
  * rails-7.0.8.5
  * rails-7.0.8.6
  * rails-7.0.8.7
  * rails-7.1.0.beta1
  * rails-7.1.0.rc1
  * rails-7.1.0.rc2
  * rails-7.1.0
  * rails-7.1.1
  * rails-7.1.2
  * rails-7.1.3
  * rails-7.1.3.1
  * rails-7.1.3.2
  * rails-7.1.3.3
  * rails-7.1.3.4
  * rails-7.1.4
  * rails-7.1.4.1
  * rails-7.1.4.2
  * rails-7.1.5
  * rails-7.1.5.1
  * rails-7.1.5.2
  * rails-7.2.0.beta1
  * rails-7.2.0.beta2
  * rails-7.2.0.beta3
  * rails-7.2.0.rc1
  * rails-7.2.0
  * rails-7.2.1
  * rails-7.2.1.1
  * rails-7.2.1.2
  * rails-7.2.2
  * rails-7.2.2.1
  * rails-7.2.2.2
  * rails-8.0.0.beta1
  * rails-8.0.0.rc1
  * rails-8.0.0.rc2
  * rails-8.0.0
  * rails-8.0.0.1
  * rails-8.0.1
  * rails-8.0.2
  * rails-8.0.2.1
  * rails-8.0.3
  * rails-8.1.0.beta1
  * rails-8.1.0.rc1
  * rails-8.1.0
Run options: --seed 62089

# Running:

........F

Fabulous run in 0.471323s, 19.0952 runs/s, 38.1904 assertions/s.

  1) Failure:
RailtieTest#test_does_not_insert_the_sidekiq_middleware_when_explicitly_enabled_but_not_set_up [test/isolated/railtie_test.rb:73]:
Expected ["GvlMetricsMiddleware::Sidekiq"] to not include "GvlMetricsMiddleware::Sidekiq".

9 runs, 18 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -w -I"lib:test" /Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/lib/rake/rake_test_loader.rb "test/isolated/**/*_test.rb" ]
/Users/joshuayoung/Projects/buildkite/gvl_metrics_middleware/gemfiles/.bundle/ruby/3.4.0/gems/rake-13.3.0/exe/rake:27:in '<top (required)>'
/Users/joshuayoung/.local/share/mise/installs/ruby/3.4.7/bin/bundle:25:in '<main>'
Tasks: TOP => default => test:isolated
(See full trace by running task with --trace)
```

</details>